### PR TITLE
Add 12 Docker practice exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# practicasdocker
+# Prácticas de Docker
+
+Este repositorio contiene una serie de ejercicios de dificultad progresiva para aprender Docker en la asignatura de Administración de Servidores.
+
+Cada práctica se encuentra en la carpeta `practicas/practicaXX` y cuenta con un `README.md` con las instrucciones necesarias. Algunas incluyen archivos de ejemplo como `Dockerfile`, `docker-compose.yml` o `Makefile`.
+
+## Lista de prácticas
+
+1. **Práctica 01:** Primeros pasos con Docker.
+2. **Práctica 02:** Construir una imagen propia.
+3. **Práctica 03:** Volúmenes de Docker.
+4. **Práctica 04:** Publicar puertos.
+5. **Práctica 05:** Redes personalizadas.
+6. **Práctica 06:** Docker Compose básico.
+7. **Práctica 07:** Volúmenes y variables en Compose.
+8. **Práctica 08:** Variables y argumentos en Dockerfile.
+9. **Práctica 09:** Multi-stage build.
+10. **Práctica 10:** Automatización con Makefile.
+11. **Práctica 11:** Multi-stage y Docker Compose.
+12. **Práctica 12:** Publicación y CI/CD.
+
+Cada ejercicio está pensado para que el estudiante ponga en práctica conceptos como redes, volúmenes, creación de imágenes personalizadas y automatización de tareas con Makefile.

--- a/practicas/practica01/README.md
+++ b/practicas/practica01/README.md
@@ -1,0 +1,9 @@
+# Práctica 01 - Primeros pasos con Docker
+
+1. Instala Docker en tu equipo.
+2. Ejecuta `docker run hello-world` para comprobar la instalación.
+3. Lista las imágenes disponibles con `docker images` y los contenedores con `docker ps -a`.
+4. Inspecciona el contenedor creado con `docker inspect`. Revisa la información de red y configuración.
+5. Elimina el contenedor y la imagen con `docker rm` y `docker rmi`.
+
+**Objetivo:** Familiarizarte con los comandos básicos de Docker.

--- a/practicas/practica02/Dockerfile
+++ b/practicas/practica02/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.11-slim
+COPY app.py /app.py
+CMD ["python", "/app.py"]

--- a/practicas/practica02/README.md
+++ b/practicas/practica02/README.md
@@ -1,0 +1,17 @@
+# Práctica 02 - Construir una imagen propia
+
+En esta práctica crearás tu primera imagen personalizada de Docker.
+
+1. Revisa el archivo `app.py` que contiene un pequeño script de Python.
+2. Analiza el `Dockerfile` y observa las instrucciones `FROM`, `COPY` y `CMD`.
+3. Construye la imagen ejecutando:
+   ```bash
+docker build -t mi-python-app .
+   ```
+4. Ejecuta un contenedor a partir de la imagen:
+   ```bash
+docker run --rm mi-python-app
+   ```
+5. Comprueba el mensaje que imprime el contenedor.
+
+**Objetivo:** Aprender a crear imágenes a partir de un `Dockerfile` sencillo.

--- a/practicas/practica02/app.py
+++ b/practicas/practica02/app.py
@@ -1,0 +1,1 @@
+print("Hola desde Docker")

--- a/practicas/practica03/README.md
+++ b/practicas/practica03/README.md
@@ -1,0 +1,12 @@
+# Práctica 03 - Volúmenes de Docker
+
+1. Crea un directorio en tu sistema anfitrión que contenga un archivo `datos.txt`.
+2. Ejecuta un contenedor de `alpine` montando dicho directorio en `/datos`:
+   ```bash
+docker run -it --name prueba-vol -v $(pwd)/mi_datos:/datos alpine sh
+   ```
+3. Dentro del contenedor verifica el contenido de `/datos` y escribe nueva información en `datos.txt`.
+4. Sal del contenedor y comprueba que el archivo de tu sistema anfitrión se ha actualizado.
+5. Elimina el contenedor con `docker rm`.
+
+**Objetivo:** Entender cómo funcionan los volúmenes para persistir información.

--- a/practicas/practica04/Dockerfile
+++ b/practicas/practica04/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/practicas/practica04/README.md
+++ b/practicas/practica04/README.md
@@ -1,0 +1,14 @@
+# Práctica 04 - Publicar puertos
+
+1. Observa el `Dockerfile` que usa la imagen `nginx` para servir el archivo `index.html`.
+2. Construye la imagen con:
+   ```bash
+docker build -t web-nginx .
+   ```
+3. Ejecuta el contenedor mapeando el puerto 8080 del anfitrión al puerto 80 del contenedor:
+   ```bash
+docker run --rm -p 8080:80 web-nginx
+   ```
+4. Abre un navegador y accede a `http://localhost:8080` para ver la página.
+
+**Objetivo:** Aprender a exponer servicios de un contenedor hacia el exterior.

--- a/practicas/practica04/index.html
+++ b/practicas/practica04/index.html
@@ -1,0 +1,1 @@
+<h1>Servidor web en Docker</h1>

--- a/practicas/practica05/README.md
+++ b/practicas/practica05/README.md
@@ -1,0 +1,12 @@
+# Práctica 05 - Redes personalizadas
+
+1. Crea una red bridge llamada `mired`:
+   ```bash
+docker network create mired
+   ```
+2. Ejecuta un contenedor `nginx` conectado a `mired` con el nombre `web`.
+3. Ejecuta un contenedor `alpine` también en `mired` y desde él haz ping al contenedor `web` para comprobar la comunicación.
+4. Inspecciona la red con `docker network inspect mired`.
+5. Elimina los contenedores y la red al finalizar.
+
+**Objetivo:** Comprender cómo funcionan las redes de Docker y la resolución de nombres entre contenedores.

--- a/practicas/practica06/README.md
+++ b/practicas/practica06/README.md
@@ -1,0 +1,12 @@
+# Práctica 06 - Docker Compose básico
+
+1. Analiza el archivo `docker-compose.yml` que define un servicio web y un servicio `redis`.
+2. Levanta los servicios ejecutando:
+   ```bash
+docker-compose up -d
+   ```
+3. Comprueba que ambos contenedores están en ejecución con `docker-compose ps`.
+4. Accede al navegador en `http://localhost:8081` para ver el contenedor `nginx`.
+5. Detén y elimina los servicios con `docker-compose down`.
+
+**Objetivo:** Introducir Docker Compose para orquestar múltiples contenedores.

--- a/practicas/practica06/docker-compose.yml
+++ b/practicas/practica06/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "8081:80"
+  redis:
+    image: redis:alpine

--- a/practicas/practica07/README.md
+++ b/practicas/practica07/README.md
@@ -1,0 +1,11 @@
+# Práctica 07 - Volúmenes y variables en Compose
+
+1. El archivo `docker-compose.yml` define un contenedor `postgres` con volumen persistente y variables de entorno.
+2. Levanta el entorno con:
+   ```bash
+docker-compose up -d
+   ```
+3. Verifica que el volumen `dbdata` se haya creado y que puedes acceder a `http://localhost:8082` para administrar la base de datos con Adminer.
+4. Detén y elimina el entorno con `docker-compose down -v` para borrar los volúmenes.
+
+**Objetivo:** Utilizar volúmenes y variables de entorno en Docker Compose.

--- a/practicas/practica07/docker-compose.yml
+++ b/practicas/practica07/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  db:
+    image: postgres:alpine
+    environment:
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+  adminer:
+    image: adminer
+    ports:
+      - "8082:8080"
+volumes:
+  dbdata:

--- a/practicas/practica08/Dockerfile
+++ b/practicas/practica08/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:latest
+ARG APP_VERSION=1.0
+ENV VERSION=$APP_VERSION
+CMD echo "Version de la app: $VERSION"

--- a/practicas/practica08/README.md
+++ b/practicas/practica08/README.md
@@ -1,0 +1,13 @@
+# Práctica 08 - Variables y argumentos en Dockerfile
+
+1. Revisa el `Dockerfile` que declara un argumento de construcción `APP_VERSION` y la variable de entorno `VERSION`.
+2. Construye la imagen indicando un valor diferente de versión:
+   ```bash
+docker build --build-arg APP_VERSION=2.5 -t app-con-arg .
+   ```
+3. Ejecuta el contenedor para ver el mensaje con la versión:
+   ```bash
+docker run --rm app-con-arg
+   ```
+
+**Objetivo:** Entender el uso de `ARG` y `ENV` para parametrizar imágenes.

--- a/practicas/practica09/Dockerfile
+++ b/practicas/practica09/Dockerfile
@@ -1,0 +1,10 @@
+# Etapa de compilación
+FROM golang:1.22-alpine AS builder
+WORKDIR /src
+COPY main.go .
+RUN go build -o app main.go
+
+# Imagen final
+FROM alpine:latest
+COPY --from=builder /src/app /app
+CMD ["/app"]

--- a/practicas/practica09/README.md
+++ b/practicas/practica09/README.md
@@ -1,0 +1,14 @@
+# Práctica 09 - Multi-stage build
+
+1. Observa el `Dockerfile` que utiliza dos etapas: `builder` para compilar un programa en Go y una imagen final minimalista.
+2. Construye la imagen ejecutando:
+   ```bash
+docker build -t app-multi-stage .
+   ```
+3. Comprueba el tamaño de la imagen resultante con `docker images app-multi-stage`.
+4. Ejecuta el contenedor:
+   ```bash
+docker run --rm app-multi-stage
+   ```
+
+**Objetivo:** Crear imágenes optimizadas utilizando el proceso de multi-stage build.

--- a/practicas/practica09/main.go
+++ b/practicas/practica09/main.go
@@ -1,0 +1,3 @@
+package main
+import "fmt"
+func main() { fmt.Println("Hola multi-stage") }

--- a/practicas/practica10/Makefile
+++ b/practicas/practica10/Makefile
@@ -1,0 +1,10 @@
+IMAGE=miapp:latest
+
+build:
+docker build -t $(IMAGE) .
+
+run:
+docker run --rm $(IMAGE)
+
+push:
+docker push $(IMAGE)

--- a/practicas/practica10/README.md
+++ b/practicas/practica10/README.md
@@ -1,0 +1,8 @@
+# Práctica 10 - Automatización con Makefile
+
+1. Examina el `Makefile` que define las tareas `build`, `run` y `push`.
+2. Ajusta la variable `IMAGE` con el nombre de tu repositorio si quieres subir la imagen a un registry.
+3. Ejecuta `make build` para crear la imagen, `make run` para probarla y `make push` para publicarla (si cuentas con un registry).
+4. Modifica o amplía las tareas según tus necesidades.
+
+**Objetivo:** Facilitar el trabajo con Docker mediante la automatización de comandos repetitivos.

--- a/practicas/practica11/Dockerfile
+++ b/practicas/practica11/Dockerfile
@@ -1,0 +1,12 @@
+# Etapa de construcción
+FROM node:20 AS build
+WORKDIR /app
+COPY . .
+RUN npm install && npm run build
+
+# Etapa de producción
+FROM node:20-slim
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+EXPOSE 8080
+CMD ["node", "dist/index.js"]

--- a/practicas/practica11/README.md
+++ b/practicas/practica11/README.md
@@ -1,0 +1,12 @@
+# Práctica 11 - Multi-stage y Docker Compose
+
+1. Revisa el `Dockerfile` que compila una aplicación de Node.js en una primera etapa y genera una imagen liviana de producción.
+2. El archivo `docker-compose.yml` usa la directiva `build` para construir la imagen y exponer el servicio por el puerto 8090.
+3. Ejecuta:
+   ```bash
+docker-compose up --build
+   ```
+4. Comprueba la aplicación en `http://localhost:8090` (la carpeta `dist` deberá contener el código compilado).
+5. Detén y elimina los contenedores con `docker-compose down`.
+
+**Objetivo:** Integrar builds multi-stage dentro de Docker Compose.

--- a/practicas/practica11/docker-compose.yml
+++ b/practicas/practica11/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+services:
+  app:
+    build: .
+    image: msapp:latest
+    ports:
+      - "8090:8080"

--- a/practicas/practica12/README.md
+++ b/practicas/practica12/README.md
@@ -1,0 +1,8 @@
+# Práctica 12 - Publicación y CI/CD
+
+1. Usa la imagen creada en la práctica anterior y súbela a un registro de contenedores propio (por ejemplo Docker Hub o GitHub Container Registry).
+2. Crea un token de acceso y configura los comandos `docker login`, `docker tag` y `docker push`.
+3. Diseña un flujo básico de CI/CD (por ejemplo con GitHub Actions) que construya la imagen multi-stage y la publique automáticamente en cada cambio de la rama principal.
+4. Prueba que puedas descargar la imagen desde otro equipo con `docker pull`.
+
+**Objetivo:** Completar el ciclo de construcción y despliegue automatizado utilizando Docker.


### PR DESCRIPTION
## Summary
- add a set of 12 practice exercises for learning Docker
- provide examples with Dockerfiles, docker-compose and Makefile
- update root README with list of practices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684512dd4c60832e94bc468a9c57a4da